### PR TITLE
Move cache configuration to initializer

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -32,7 +32,6 @@ Rails.application.configure do
   # Raises helpful error messages.
   config.assets.raise_runtime_errors = true
 
-  config.cache_store = :memory_store, { size: 64.megabytes }
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,8 +53,6 @@ Rails.application.configure do
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
-  config.cache_store = :memory_store, { size: 64.megabytes }
-
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = "http://assets.example.com"
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -15,7 +15,6 @@ Rails.application.configure do
   # Configure static asset server for tests with Cache-Control for performance.
   config.serve_static_assets  = true
   config.static_cache_control = "public, max-age=3600"
-  config.cache_store = :memory_store, { size: 64.megabytes }
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true

--- a/config/initializers/cache.rb
+++ b/config/initializers/cache.rb
@@ -1,0 +1,1 @@
+ActionController::Base.cache_store = :memory_store, { size: 64.megabytes }


### PR DESCRIPTION
As mentioned in commit 9df92e, removing jbuilder caused this cache
configuration code to fail. This is because we shouldn't be doing cache
configuration in the environment files. We should do it in an
initializer, which is called after ActiveSupport is loaded. So it'll run
whether or not jbuilder is installed
