### PR TITLE
Show LE courses as of Fall 2015 term

### DIFF
--- a/app/models/db_course_repository.rb
+++ b/app/models/db_course_repository.rb
@@ -7,7 +7,7 @@ class DbCourseRepository < ActiveRecord::Base
     with crse_catalog_eff_keys as (
       select crse_id, max(effdt) as effdt
       from #{AsrWarehouse.schema_name}.ps_crse_catalog
-      where effdt <= sysdate
+      where effdt <= '2015-09-08'
       group by crse_id
     ),
     eff_crse_catalog as (


### PR DESCRIPTION
This is a short term fix for issue #17 until we figure out how to solve
this feature long term. Instead of getting the most recent effective row
as of today, this query now gets the most recent row as of 9/8/2015.
Looking at the course catalog, that's the date used to for changes that
become effective with the Fall 2015 term.
