### PR TITLE
Update the effdt for courses

### DIFF
--- a/app/models/db_course_repository.rb
+++ b/app/models/db_course_repository.rb
@@ -7,7 +7,7 @@ class DbCourseRepository < ActiveRecord::Base
     with crse_catalog_eff_keys as (
       select crse_id, max(effdt) as effdt
       from #{AsrWarehouse.schema_name}.ps_crse_catalog
-      where effdt <= '2015-09-08'
+      where effdt <= '2016-01-19'
       group by crse_id
     ),
     eff_crse_catalog as (


### PR DESCRIPTION
This fixes #20.  We needed to update the effdt we filter on so that we
return courses that meet the Liberal Education Requirements as of Spring
2016.  1/19/2016 is the start of Spring 2016 term.
